### PR TITLE
fix: Bump base java helm chart to 3.7.1

### DIFF
--- a/charts/rd-commondata-api/Chart.yaml
+++ b/charts/rd-commondata-api/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "1.0"
 description: A Helm chart for rd-commondata-api
 name: rd-commondata-api
 home: https://github.com/hmcts/rd-commondata-api
-version: 0.0.3
+version: 0.0.4
 maintainers:
   - name: Reference Data Team
 dependencies:

--- a/charts/rd-commondata-api/Chart.yaml
+++ b/charts/rd-commondata-api/Chart.yaml
@@ -8,5 +8,5 @@ maintainers:
   - name: Reference Data Team
 dependencies:
   - name: java
-    version: 3.6.0
+    version: 3.7.1
     repository: '@hmctspublic'


### PR DESCRIPTION
### JIRA link ###

https://tools.hmcts.net/jira/browse/RDCC-4056

### Change description ###

fix: Bump base java helm chart to 3.7.1 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```