### PR TITLE
fix: RDCC-5392 Fix CVE-2022-25857

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -361,7 +361,11 @@ dependencies {
   implementation group: 'io.github.openfeign.form', name: 'feign-form-spring', version: versions.feign
   implementation "io.github.openfeign:feign-httpclient:11.0"
   implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: versions.log4j
-  implementation group: 'org.yaml', name: 'snakeyaml', version: '1.31'
+  implementation(group: 'org.yaml', name: 'snakeyaml') {
+        version {
+            strictly '1.31'
+        }
+    }
 
   testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.17.2'
   testImplementation "org.testcontainers:junit-jupiter:1.17.2"

--- a/build.gradle
+++ b/build.gradle
@@ -320,7 +320,9 @@ dependencies {
   implementation group: 'io.springfox', name: 'springfox-swagger-ui', version: versions.springfoxSwagger
   implementation group: 'org.flywaydb', name: 'flyway-core', version: '8.5.12'
   implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
-  implementation group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: versions.launchDarklySdk
+  implementation (group: 'com.launchdarkly', name: 'launchdarkly-java-server-sdk', version: versions.launchDarklySdk) {
+    exclude group: "org.yaml", module: "snakeyaml"
+  }
   implementation group: 'uk.gov.hmcts.reform', name: 'service-auth-provider-client', version: versions.reformS2sClient
   implementation group: 'javax.inject', name: 'javax.inject', version: '1'
   implementation "com.github.hmcts.java-logging:logging:${versions.reformLogging}"
@@ -361,11 +363,8 @@ dependencies {
   implementation group: 'io.github.openfeign.form', name: 'feign-form-spring', version: versions.feign
   implementation "io.github.openfeign:feign-httpclient:11.0"
   implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: versions.log4j
-  implementation(group: 'org.yaml', name: 'snakeyaml') {
-        version {
-            strictly '1.31'
-        }
-    }
+  implementation group: 'org.yaml', name: 'snakeyaml', version: '1.31'
+
 
   testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.17.2'
   testImplementation "org.testcontainers:junit-jupiter:1.17.2"

--- a/build.gradle
+++ b/build.gradle
@@ -361,6 +361,7 @@ dependencies {
   implementation group: 'io.github.openfeign.form', name: 'feign-form-spring', version: versions.feign
   implementation "io.github.openfeign:feign-httpclient:11.0"
   implementation group: 'org.apache.logging.log4j', name: 'log4j-core', version: versions.log4j
+  implementation group: 'org.yaml', name: 'snakeyaml', version: '1.31'
 
   testImplementation group: 'org.testcontainers', name: 'postgresql', version: '1.17.2'
   testImplementation "org.testcontainers:junit-jupiter:1.17.2"


### PR DESCRIPTION
### JIRA link  ###
https://tools.hmcts.net/jira/browse/RDCC-5392


### Change description ###
 Fixed CVE-2022-25857 by upgrading snakeyaml to version 1.31


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
