### PR TITLE
RDCC-5671 Common: Change in the LoV API to return the generic category details when a Service ID is passed as an input parameter

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/cdapi/CommonDataApiFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/cdapi/CommonDataApiFunctionalTest.java
@@ -37,6 +37,12 @@ class CommonDataApiFunctionalTest extends AuthorizationFunctionalTest {
     private static final String PARAM_SIGN = "?";
     private static final String PARAM_HEARING = SLASH.concat("HearingChannel");
     private static final String PARAM_HEARING_WITH_PARAM_SIGN = PARAM_HEARING.concat(PARAM_SIGN);
+    private static final String SERVICE_ID = "ServiceId=";
+    private static final String SERVICE_ID_BBA3 = "BBA3";
+    private static final String PARAM_LISTING_STATUS_WITH_SERVICE_ID = SLASH.concat("ListingStatus")
+        .concat(PARAM_SIGN).concat(SERVICE_ID+SERVICE_ID_BBA3);
+    private static final String PARAM_LISTING_STATUS_WITH_EMPTY_SERVICE_ID = SLASH.concat("ListingStatus")
+        .concat(PARAM_SIGN).concat(SERVICE_ID);
     private static final String DATA_NOT_FOUND = "Data not found";
 
     @Test
@@ -304,5 +310,39 @@ class CommonDataApiFunctionalTest extends AuthorizationFunctionalTest {
         }
     }
 
+    @Test
+    @ToggleEnable(mapKey = MAP_KEY_LOV, withFeature = true)
+    @ExtendWith(FeatureToggleConditionExtension.class)
+    void shouldReturnSuccess_Valid_ServiceID() {
+        Response response =
+            commonDataApiClient.retrieveCategoriesByCategoryIdSuccess(PATH_LOV, PARAM_LISTING_STATUS_WITH_SERVICE_ID);
+        if (OK.value() == response.getStatusCode()) {
+            var categories = response.getBody().as(Categories.class);
+            assertNotNull(categories);
+            assertThat(categories.getListOfCategory()).hasSizeGreaterThan(1);
+            categories.getListOfCategory().forEach(h -> assertEquals("ListingStatus", h.getCategoryKey()));
+        } else {
+            assertEquals(NOT_FOUND.value(), response.getStatusCode());
+        }
+    }
+
+    @Test
+    @ToggleEnable(mapKey = MAP_KEY_LOV, withFeature = true)
+    @ExtendWith(FeatureToggleConditionExtension.class)
+    void shouldReturnSuccess_Empty_ServiceID() {
+        Response response =
+            commonDataApiClient.retrieveCategoriesByCategoryIdSuccess(
+                PATH_LOV,
+                PARAM_LISTING_STATUS_WITH_EMPTY_SERVICE_ID
+            );
+        if (OK.value() == response.getStatusCode()) {
+            var categories = response.getBody().as(Categories.class);
+            assertNotNull(categories);
+            assertThat(categories.getListOfCategory()).hasSizeGreaterThan(1);
+            categories.getListOfCategory().forEach(h -> assertEquals("ListingStatus", h.getCategoryKey()));
+        } else {
+            assertEquals(NOT_FOUND.value(), response.getStatusCode());
+        }
+    }
 
 }

--- a/src/functionalTest/java/uk/gov/hmcts/reform/cdapi/CommonDataApiFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/cdapi/CommonDataApiFunctionalTest.java
@@ -40,7 +40,7 @@ class CommonDataApiFunctionalTest extends AuthorizationFunctionalTest {
     private static final String SERVICE_ID = "ServiceId=";
     private static final String SERVICE_ID_BBA3 = "BBA3";
     private static final String PARAM_LISTING_STATUS_WITH_SERVICE_ID = SLASH.concat("ListingStatus")
-        .concat(PARAM_SIGN).concat(SERVICE_ID+SERVICE_ID_BBA3);
+        .concat(PARAM_SIGN).concat(SERVICE_ID + SERVICE_ID_BBA3);
     private static final String PARAM_LISTING_STATUS_WITH_EMPTY_SERVICE_ID = SLASH.concat("ListingStatus")
         .concat(PARAM_SIGN).concat(SERVICE_ID);
     private static final String DATA_NOT_FOUND = "Data not found";

--- a/src/integrationTest/java/uk/gov/hmcts/reform/cdapi/RetrieveCategoriesIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/cdapi/RetrieveCategoriesIntegrationTest.java
@@ -129,4 +129,52 @@ public class RetrieveCategoriesIntegrationTest extends CdAuthorizationEnabledInt
         }
     }
 
+    @Test
+    void shouldRetrieveCategoriesWithEmptyServiceIdWithChildNodes()
+        throws JsonProcessingException {
+        final var response = (Categories)
+            commonDataApiClient.retrieveCaseFlagsByServiceId("ListingStatus?"
+                                                                 + "&isChildRequired=Y&serviceId=",
+                                                             Categories.class, path
+            );
+        Category category = response.getListOfCategory().get(0);
+        assertNotNull(category);
+        assertEquals(1, response.getListOfCategory().size());
+        assertThat(category.getKey()).isEqualTo("test");
+        assertThat(category.getValueEn()).isEqualTo("test");
+        assertThat(category.getValueCy()).isNull();
+        assertThat(category.getHintTextCy()).isNull();
+        assertThat(category.getHintTextEn()).isNull();
+        assertThat(category.getLovOrder()).isNull();
+        assertThat(category.getParentCategory()).isNull();
+        assertThat(category.getParentKey()).isNull();
+        assertThat(category.getActiveFlag()).isEqualTo("Y");
+        assertEquals(1,category.getChildNodes().size());
+        assertThat(category.getChildNodes().get(0).getCategoryKey()).isEqualTo("ListingStatusSubChannel");
+        assertThat(category.getChildNodes().get(0).getParentKey()).isEqualTo("test");
+        assertThat(category.getChildNodes().get(0).getParentCategory()).isEqualTo("ListingStatus");
+    }
+
+    @Test
+    void shouldRetrieveCategoriesWithEmptyServiceIdWithoutChildNodes()
+        throws JsonProcessingException {
+        final var response = (Categories)
+            commonDataApiClient.retrieveCaseFlagsByServiceId("EmptySubCategory?"
+                                                                 + "&isChildRequired=Y&serviceId=",
+                                                             Categories.class, path
+            );
+        Category category = response.getListOfCategory().get(0);
+        assertNotNull(category);
+        assertEquals(1, response.getListOfCategory().size());
+        assertThat(category.getKey()).isEqualTo("test");
+        assertThat(category.getValueEn()).isEqualTo("test");
+        assertThat(category.getValueCy()).isNull();
+        assertThat(category.getHintTextCy()).isNull();
+        assertThat(category.getHintTextEn()).isNull();
+        assertThat(category.getLovOrder()).isNull();
+        assertThat(category.getParentCategory()).isNull();
+        assertThat(category.getParentKey()).isNull();
+        assertThat(category.getActiveFlag()).isEqualTo("Y");
+        assertNull(category.getChildNodes());
+    }
 }

--- a/src/integrationTest/resources/db/testmigration/V1_6__Alter_List_Of_Values.sql
+++ b/src/integrationTest/resources/db/testmigration/V1_6__Alter_List_Of_Values.sql
@@ -10,5 +10,8 @@ VALUES ('HearingChannel','BBA3','telephone','Telephone',null,null,null,2,null,nu
 ('HearingChannel','BBA3','video','Video',null,null,null,3,null,null,'Y'),
 ('HearingChannel','BBA3','faceToFace','Face To Face',null,null,null,1,null,null,'Y'),
 ('HearingChannel','BBA3','notAttending','Not Attending',null,null,null,4,null,null,'Y'),
-('HearingSubChannel','BBA3','telephone-btMeetMe','Telephone - BTMeetme',null,null,null,null,'HearingChannel','telephone','Y');
+('HearingSubChannel','BBA3','telephone-btMeetMe','Telephone - BTMeetme',null,null,null,null,'HearingChannel','telephone','Y'),
+('ListingStatus','','test','test',null,null,null,null,null,null,'Y'),
+('EmptySubCategory','','test','test',null,null,null,null,null,null,'Y'),
+('ListingStatusSubChannel','','test','test',null,null,null,null,'ListingStatus','test','Y');
 

--- a/src/main/java/uk/gov/hmcts/reform/cdapi/domain/QuerySpecification.java
+++ b/src/main/java/uk/gov/hmcts/reform/cdapi/domain/QuerySpecification.java
@@ -21,7 +21,13 @@ public class QuerySpecification {
     public static Specification<ListOfValueDto> serviceId(String serviceId) {
         return (root, query, builder) ->
             serviceId == null ? builder.conjunction() :
-                builder.equal(builder.lower(root.get("categoryKey").get("serviceId")), serviceId.toLowerCase().trim());
+                builder.or(
+                    builder.equal(
+                        builder.lower(root.get("categoryKey").get("serviceId")),
+                        serviceId.toLowerCase().trim()
+                    ),
+                    builder.equal(root.get("categoryKey").get("serviceId"), "")
+                );
     }
 
     /**

--- a/src/test/java/uk/gov/hmcts/reform/cdapi/domain/QuerySpecificationTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/cdapi/domain/QuerySpecificationTest.java
@@ -91,6 +91,16 @@ class QuerySpecificationTest {
     }
 
     @Test
+    void retrieveServiceId_withEmpty() {
+        doReturn(pathObj).when(root).get(anyString());
+        doReturn(predicate).when(specMock).toPredicate(root, query, builder);
+        Specification<ListOfValueDto> result = QuerySpecification.serviceId("");
+        result = result.and(specMock);
+        Assertions.assertThat(result).isNotNull();
+        MatcherAssert.assertThat(result.toPredicate(root, query, builder), is(predicate));
+    }
+
+    @Test
     void retrieveServiceId_withNull() {
 
         Specification<ListOfValueDto> result = QuerySpecification.serviceId(null);


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RDCC-5671

### Change description ###

Common: Change in the LoV API to return the generic category details when a Service ID is passed as an input parameter

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
