### PR TITLE
returning child categories with service id and parentcategory and key…

### DIFF
--- a/src/functionalTest/java/uk/gov/hmcts/reform/cdapi/CommonDataApiFunctionalTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/cdapi/CommonDataApiFunctionalTest.java
@@ -274,14 +274,13 @@ class CommonDataApiFunctionalTest extends AuthorizationFunctionalTest {
     void shouldReturnChildCategoriesInParticularToServiceId() {
         Response response =
             commonDataApiClient.retrieveCategoriesByCategoryIdSuccess(PATH_LOV, "/HearingChannel?"
-                + "isChildRequired=y&serviceId=BBA3");
+                + "isChildRequired=y&serviceId=BBA3&key=VID");
 
         if (OK.value() == response.getStatusCode()) {
             var categories = response.getBody().as(Categories.class);
             assertNotNull(categories);
             categories.getListOfCategory().forEach(h -> assertEquals("HearingChannel", h.getCategoryKey()));
             assertThat(categories.getListOfCategory()).hasSizeGreaterThan(0);
-            assertThat(categories.getListOfCategory().get(0).getChildNodes()).hasSizeGreaterThan(0);
             assertThat(categories.getListOfCategory().get(0).getChildNodes()).hasSizeGreaterThan(0);
             assertEquals("HearingChannel",categories.getListOfCategory().get(0).getChildNodes().get(0)
                 .getParentCategory());


### PR DESCRIPTION
Functional Test changes

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
