### PR TITLE
Addresses CVE-2023-20863

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ def versions = [
   serenity        : '2.0.76',
   springHystrix   : '2.2.10.RELEASE',
   restAssured     : '4.3.3',
-  springVersion   : '5.3.26',
+  springVersion   : '5.3.27',
   logback         : '1.2.10',
   feign           : '3.8.0',
   bytebuddy       : '1.12.7',


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSRD-264

### Change description ###

Addresses nightly build failure due to https://github.com/advisories/GHSA-wxqc-pxw9-g2p8

Mitigated in spring 5.3.27
https://spring.io/security/cve-2023-20863

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
