### PR TITLE
DTSRD-3580 Jenkins Test Reports to Publish on Failure 

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -72,7 +72,7 @@ withPipeline(type, product, component) {
       env.TEST_URL = "http://rd-commondata-api-aat.aat.platform.hmcts.net"
     }
 
-  afterSuccess('sonarscan') {
+  afterAlways('sonarscan') {
     publishHTML target: [
       allowMissing         : true,
       alwaysLinkToLastBuild: true,
@@ -92,7 +92,7 @@ withPipeline(type, product, component) {
     ]
   }
 
-  afterSuccess('smoketest:preview') {
+  afterAlways('smoketest:preview') {
     publishHTML target: [
       allowMissing         : true,
       alwaysLinkToLastBuild: true,
@@ -103,7 +103,7 @@ withPipeline(type, product, component) {
     ]
   }
 
-  afterSuccess('smoketest:aat') {
+  afterAlways('smoketest:aat') {
     publishHTML target: [
       allowMissing         : true,
       alwaysLinkToLastBuild: true,
@@ -114,7 +114,7 @@ withPipeline(type, product, component) {
     ]
   }
 
-  afterSuccess('functionalTest:aat') {
+  afterAlways('functionalTest:aat') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     publishHTML target: [
       allowMissing         : true,
@@ -126,7 +126,7 @@ withPipeline(type, product, component) {
     ]
   }
 
-  afterSuccess('functionalTest:preview') {
+  afterAlways('functionalTest:preview') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     publishHTML target: [
       allowMissing         : true,
@@ -138,7 +138,7 @@ withPipeline(type, product, component) {
     ]
   }
 
-  afterSuccess('pact-provider-verification') {
+  afterAlways('pact-provider-verification') {
     publishHTML target: [
       allowMissing         : true,
       alwaysLinkToLastBuild: true,

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -67,7 +67,7 @@ withNightlyPipeline(type, product, component) {
   enableSecurityScan()
   enableFortifyScan()
 
-  afterSuccess('mutationTest') {
+  afterAlways('mutationTest') {
     publishHTML target: [
       allowMissing         : true,
       alwaysLinkToLastBuild: true,
@@ -77,7 +77,7 @@ withNightlyPipeline(type, product, component) {
       reportName           : "Mutation Test Report"
     ]
   }
-  afterSuccess('fullFunctionalTest') {
+  afterAlways('fullFunctionalTest') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'build/reports/**/*'
     publishHTML target: [
@@ -90,7 +90,7 @@ withNightlyPipeline(type, product, component) {
     ]
   }
 
-  afterSuccess('fortify-scan') {
+  afterAlways('fortify-scan') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/Fortify Scan/**/*'
   }
 }


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSRD-3580

### Change description ###
Jenkins Test Reports to Publish on Failure - afterSuccess() replaced with afterAlways() for all reports in Jenkinsfile_CNP and nightly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
